### PR TITLE
Deprecate repo, point to Pagure

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 
 FeedCloud
 =========
+
+## [Project moved to Pagure](https://pagure.io/feedcloud)
+
+**Please file any issues or pull requests against the [Pagure project](https://pagure.io/feedcloud)!**
+
+
 This is a set of scripts that pull from a list of RSS/XML/ATOM feeds, and write
 those contents to text corpi, to be fed into word_cloud. You will need to
 install word_cloud as noted below.


### PR DESCRIPTION
As discussed earlier, this repository was migrated to Pagure to improve accessibility and visibility for other Fedora contributors. This project can be found [here](https://pagure.io/feedcloud).

This PR adds a note to the README pointing to the new home for the project, along with instructions to file issues and pull requests against the Pagure repo.
